### PR TITLE
Added functionality to push verified commits from devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,13 @@
 		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 		"dockerfile": "../Dockerfile"
 	},
-
+	"mounts": [],
+	// For this to work the user needs to have a valid SSH key in their home directory called id_ed25519.pub
+	"postStartCommand": "git config --global gpg.format ssh; git config --global user.signingkey /root/.ssh/id_ed25519.pub",
+	"runArgs": [
+		"--name", "pulumi-pve",
+		"-v", "${localEnv:HOME}/.ssh/id_ed25519.pub:/root/.ssh/id_ed25519.pub:Z"
+		],
 	"customizations": {
 			"vscode": {
 				"extensions": [


### PR DESCRIPTION
# Added

- A simple volume mount to mount the user's id_ed25519.pub file to the container.
- A postStartCommand to tell git to use the mounted public key to push verify commits.

For this to work correctly, the user needs a .ssh/id_ed25519.pub file in their $HOME directory. This should work for both Windows, WSL and simple Linux based systems too.
