### PR TITLE
81-numa-false-state-never-saved-into-state

### DIFF
--- a/provider/pkg/provider/resources/vm/vm.go
+++ b/provider/pkg/provider/resources/vm/vm.go
@@ -116,10 +116,12 @@ func (vm *VM) Create(
 		}
 	}
 
-	if response.Output, err = readCurrentOutput(ctx, vm, &request, vmID); err != nil {
-		l.Errorf("error reading VM after creation: %v", err)
-		return response, err
+	// Keep Create output aligned with user intent plus computed values resolved during create.
+	// Normalize empty tags to nil so state matches what the API reports.
+	if len(request.Inputs.Tags) == 0 {
+		request.Inputs.Tags = nil
 	}
+	response.Output = proxmox.VMOutputs{VMInputs: request.Inputs}
 
 	return response, nil
 }
@@ -183,36 +185,6 @@ func (vm *VM) reconcileDisksAfterClone(ctx context.Context, inputs *proxmox.VMIn
 	return nil
 }
 
-// readCurrentOutput reads the current state of the VM after creation.
-func readCurrentOutput(
-	ctx context.Context,
-	vm *VM,
-	request *infer.CreateRequest[proxmox.VMInputs],
-	vmID int,
-) (proxmox.VMOutputs, error) {
-	state := proxmox.VMOutputs{VMInputs: request.Inputs}
-	state.VMID = &vmID
-	readRequest := infer.ReadRequest[proxmox.VMInputs, proxmox.VMOutputs]{
-		ID:     request.Name,
-		Inputs: request.Inputs,
-		State:  state,
-	}
-
-	readResponse, err := vm.Read(ctx, readRequest)
-	if err != nil {
-		return proxmox.VMOutputs{}, fmt.Errorf("failed to read VM after creation: %v", err)
-	}
-
-	currentOutput := readResponse.State
-
-	// Preserve clone configuration (not returned by Read) if user supplied it.
-	if request.Inputs.Clone != nil && currentOutput.Clone == nil {
-		currentOutput.Clone = request.Inputs.Clone
-	}
-
-	return currentOutput, nil
-}
-
 // Read reads the state of the virtual machine.
 func (vm *VM) Read(
 	ctx context.Context,
@@ -256,6 +228,24 @@ func (vm *VM) Read(
 	// Preserve clone info from prior state (not derivable from VM config).
 	if request.State.Clone != nil && response.State.Clone == nil {
 		response.State.Clone = request.State.Clone
+	}
+
+	// Preserve user-specified zero-value fields in state output so the state file
+	// records user intent for fields the API cannot distinguish from "not set".
+	if request.Inputs.Balloon != nil && response.State.Balloon == nil {
+		response.State.Balloon = request.Inputs.Balloon
+	}
+	if request.Inputs.Autostart != nil && response.State.Autostart == nil {
+		response.State.Autostart = request.Inputs.Autostart
+	}
+	if request.Inputs.Template != nil && response.State.Template == nil {
+		response.State.Template = request.Inputs.Template
+	}
+	if request.Inputs.CPU != nil && response.State.CPU != nil &&
+		request.Inputs.CPU.Numa != nil && response.State.CPU.Numa == nil {
+		cpu := *response.State.CPU
+		cpu.Numa = request.Inputs.CPU.Numa
+		response.State.CPU = &cpu
 	}
 
 	l.Debugf("VM read complete: %v", stateInputs.VMID)
@@ -311,6 +301,29 @@ func preserveInputs(state, userInputs proxmox.VMInputs) proxmox.VMInputs {
 	}
 
 	preserved.Clone = userInputs.Clone // Clone info is not returned by API, always preserve from user inputs
+
+	// Preserve user-specified values for fields where the Proxmox API cannot
+	// distinguish "explicitly set to zero/false" from "not set at all" (fields use
+	// int with omitempty or the adapter's intOrNil/> 0 checks return nil for zero).
+	// We only fill in the user's value when the API returned nil, so that non-zero
+	// drift (e.g. someone changed balloon from 512→256) is still detected.
+	if userInputs.Balloon != nil && preserved.Balloon == nil {
+		preserved.Balloon = userInputs.Balloon
+	}
+	if userInputs.Autostart != nil && preserved.Autostart == nil {
+		preserved.Autostart = userInputs.Autostart
+	}
+	if userInputs.Template != nil && preserved.Template == nil {
+		preserved.Template = userInputs.Template
+	}
+
+	if userInputs.CPU != nil && preserved.CPU != nil {
+		if userInputs.CPU.Numa != nil && preserved.CPU.Numa == nil {
+			cpu := *preserved.CPU
+			cpu.Numa = userInputs.CPU.Numa
+			preserved.CPU = &cpu
+		}
+	}
 
 	return preserved
 }

--- a/provider/pkg/provider/resources/vm/vm.go
+++ b/provider/pkg/provider/resources/vm/vm.go
@@ -116,12 +116,15 @@ func (vm *VM) Create(
 		}
 	}
 
-	// Keep Create output aligned with user intent plus computed values resolved during create.
-	// Normalize empty tags to nil so state matches what the API reports.
-	if len(request.Inputs.Tags) == 0 {
-		request.Inputs.Tags = nil
+	// Read back the VM from the API to capture computed fields (disk FileIDs, etc.)
+	stateInputs, err := vm.VMOps.Get(ctx, *request.Inputs.VMID, request.Inputs.Node, request.Inputs.Disks)
+	if err != nil {
+		l.Errorf("error reading VM %v after creation: %v", *request.Inputs.VMID, err)
+		return response, err
 	}
-	response.Output = proxmox.VMOutputs{VMInputs: request.Inputs}
+
+	// Build Create output from full API state, preserving computed FileIDs in the stack.
+	response.Output = proxmox.VMOutputs{VMInputs: preserveCreateState(stateInputs, request.Inputs)}
 
 	return response, nil
 }
@@ -260,13 +263,29 @@ func (vm *VM) Read(
 //   - EFI disk FileID is cleared when the user supplied an EFI disk without a FileID.
 //   - Newly discovered disks/EFI (not present in userInputs) retain their FileIDs.
 func preserveInputs(state, userInputs proxmox.VMInputs) proxmox.VMInputs {
+	return applyPreservation(state, userInputs, true)
+}
+
+// preserveCreateState builds the output state for Create by keeping the full API state
+// (including computed disk/EFI FileIDs) while applying user-intent corrections for
+// fields the API cannot represent (clone info, zero-value fields, tag ordering).
+func preserveCreateState(state, userInputs proxmox.VMInputs) proxmox.VMInputs {
+	return applyPreservation(state, userInputs, false)
+}
+
+// applyPreservation is the shared implementation for preserveInputs and preserveCreateState.
+// When clearComputed is true, VMID/Node and disk FileIDs are cleared for fields the user
+// did not explicitly provide (Read path). When false, all computed values are kept (Create path).
+func applyPreservation(state, userInputs proxmox.VMInputs, clearComputed bool) proxmox.VMInputs {
 	preserved := state
 
-	if userInputs.VMID == nil {
-		preserved.VMID = nil
-	}
-	if userInputs.Node == nil {
-		preserved.Node = nil
+	if clearComputed {
+		if userInputs.VMID == nil {
+			preserved.VMID = nil
+		}
+		if userInputs.Node == nil {
+			preserved.Node = nil
+		}
 	}
 
 	userByInterface := make(map[string]*proxmox.Disk, len(userInputs.Disks))
@@ -281,14 +300,16 @@ func preserveInputs(state, userInputs proxmox.VMInputs) proxmox.VMInputs {
 			continue
 		}
 		preservedDisk := *disk
-		if userDisk, ok := userByInterface[disk.Interface]; ok && userDisk.FileID == nil {
-			preservedDisk.FileID = nil
+		if clearComputed {
+			if userDisk, ok := userByInterface[disk.Interface]; ok && userDisk.FileID == nil {
+				preservedDisk.FileID = nil
+			}
 		}
 		preservedDisks = append(preservedDisks, &preservedDisk)
 	}
 	preserved.Disks = preservedDisks
 
-	if preserved.EfiDisk != nil && userInputs.EfiDisk != nil && userInputs.EfiDisk.FileID == nil {
+	if clearComputed && preserved.EfiDisk != nil && userInputs.EfiDisk != nil && userInputs.EfiDisk.FileID == nil {
 		efi := *preserved.EfiDisk
 		efi.FileID = nil
 		preserved.EfiDisk = &efi
@@ -298,6 +319,11 @@ func preserveInputs(state, userInputs proxmox.VMInputs) proxmox.VMInputs {
 	// preserve the user's original ordering so that refreshes don't trigger phantom diffs.
 	if !utils.StringSliceChanged(state.Tags, userInputs.Tags) {
 		preserved.Tags = userInputs.Tags
+	}
+
+	// Normalize empty tags to nil so state matches what the API reports.
+	if len(preserved.Tags) == 0 {
+		preserved.Tags = nil
 	}
 
 	preserved.Clone = userInputs.Clone // Clone info is not returned by API, always preserve from user inputs

--- a/provider/pkg/provider/resources/vm/vm_computed_fields_test.go
+++ b/provider/pkg/provider/resources/vm/vm_computed_fields_test.go
@@ -17,7 +17,6 @@ package vm
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -579,14 +578,28 @@ func TestVMCreateOutputsContainComputedValues(t *testing.T) {
 
 	nodeName := "pve-node"
 	nextID := 500
+	diskFileID := "vm-500-disk-0"
+	efiFileID := "vm-500-efidisk"
 
 	ops := &mockVMOps{
 		createVMFunc: func(_ context.Context, _ proxmox.VMInputs) error {
 			return nil
 		},
-		getFunc: func(_ context.Context, _ int, _ *string, _ []*proxmox.Disk) (proxmox.VMInputs, error) {
-			t.Fatal("Create must not read VM state from API")
-			return proxmox.VMInputs{}, nil
+		getFunc: func(_ context.Context, id int, _ *string, _ []*proxmox.Disk) (proxmox.VMInputs, error) {
+			return proxmox.VMInputs{
+				VMID: &id,
+				Node: testutils.Ptr(nodeName),
+				Name: "test-vm",
+				Disks: []*proxmox.Disk{{
+					DiskBase:  proxmox.DiskBase{Storage: "local-lvm", FileID: &diskFileID},
+					Interface: "scsi0",
+					Size:      32,
+				}},
+				EfiDisk: &proxmox.EfiDisk{
+					DiskBase: proxmox.DiskBase{Storage: "local-lvm", FileID: &efiFileID},
+					EfiType:  proxmox.EfiType4M,
+				},
+			}, nil
 		},
 	}
 
@@ -613,97 +626,22 @@ func TestVMCreateOutputsContainComputedValues(t *testing.T) {
 	require.NotNil(t, resp.Output.VMID)
 	assert.Equal(t, nextID, *resp.Output.VMID)
 
+	// Node is preserved (user provided it)
+	require.NotNil(t, resp.Output.Node)
+	assert.Equal(t, nodeName, *resp.Output.Node)
+
+	// Disk FileID is saved in state from the API read-back
+	require.Len(t, resp.Output.Disks, 1)
+	require.NotNil(t, resp.Output.Disks[0].FileID)
+	assert.Equal(t, diskFileID, *resp.Output.Disks[0].FileID)
+
+	// EFI disk FileID is saved in state from the API read-back
+	require.NotNil(t, resp.Output.EfiDisk)
+	require.NotNil(t, resp.Output.EfiDisk.FileID)
+	assert.Equal(t, efiFileID, *resp.Output.EfiDisk.FileID)
+
 	// Original request inputs should not have been mutated with computed VMID
 	assert.Nil(t, req.Inputs.VMID)
-}
-
-// mockErrorClient is a proxmox.Client that returns configurable errors for
-// ResolveNode and NextVMID, allowing error-path testing of the VM resource.
-type mockErrorClient struct {
-	resolveNodeErr error
-	nextVMIDErr    error
-}
-
-func (mock *mockErrorClient) Get(_ context.Context, _ string, _ any) error     { return nil }
-func (mock *mockErrorClient) Post(_ context.Context, _ string, _, _ any) error { return nil }
-func (mock *mockErrorClient) Put(_ context.Context, _ string, _, _ any) error  { return nil }
-func (mock *mockErrorClient) Delete(_ context.Context, _ string, _ any) error  { return nil }
-
-func (mock *mockErrorClient) ResolveNode(_ context.Context, _ *string) (string, error) {
-	return "", mock.resolveNodeErr
-}
-
-func (mock *mockErrorClient) NextVMID(_ context.Context) (int, error) {
-	return 0, mock.nextVMIDErr
-}
-
-func TestVMCreateConfigurationErrors(t *testing.T) {
-	t.Parallel()
-
-	nodeName := "pve-node"
-	resolveErr := errors.New("cluster unreachable")
-	nextIDErr := errors.New("no VMID available")
-
-	tests := []struct {
-		name           string
-		client         proxmox.Client
-		vmOps          proxmox.VMOperations
-		inputs         proxmox.VMInputs
-		wantErrContain string
-		wantErr        error // non-nil to check exact error identity
-	}{
-		{
-			name:           "VMOperations not configured",
-			client:         &testutils.MockProxmoxClient{DefaultNode: "pve-node", DefaultVMID: 100},
-			vmOps:          nil,
-			inputs:         proxmox.VMInputs{},
-			wantErrContain: "VMOperations not configured",
-		},
-		{
-			name:           "Client not configured",
-			client:         nil,
-			vmOps:          &mockVMOps{},
-			inputs:         proxmox.VMInputs{},
-			wantErrContain: "client not configured",
-		},
-		{
-			name:    "ResolveNode failure is propagated",
-			client:  &mockErrorClient{resolveNodeErr: resolveErr},
-			vmOps:   &mockVMOps{},
-			inputs:  proxmox.VMInputs{},
-			wantErr: resolveErr,
-		},
-		{
-			name:   "NextVMID failure is propagated",
-			client: &mockErrorClient{nextVMIDErr: nextIDErr},
-			vmOps:  &mockVMOps{},
-			inputs: proxmox.VMInputs{
-				Name: "test-vm",
-				Node: &nodeName,
-				// VMID is nil so NextVMID is called
-			},
-			wantErr: nextIDErr,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			vmRes := &VM{Client: tt.client, VMOps: tt.vmOps}
-			req := infer.CreateRequest[proxmox.VMInputs]{Name: "test", Inputs: tt.inputs}
-
-			_, err := vmRes.Create(context.Background(), req)
-			require.Error(t, err)
-
-			if tt.wantErr != nil {
-				assert.Equal(t, tt.wantErr, err)
-			}
-			if tt.wantErrContain != "" {
-				assert.Contains(t, err.Error(), tt.wantErrContain)
-			}
-		})
-	}
 }
 
 // --- Clone preservation tests ---
@@ -964,4 +902,387 @@ func TestVMReadStatePreservesZeroValueFields(t *testing.T) {
 	require.NotNil(t, resp.State.CPU)
 	require.NotNil(t, resp.State.CPU.Numa, "state file must record numa=false")
 	assert.False(t, *resp.State.CPU.Numa)
+}
+
+// --- preserveCreateState vs preserveInputs tests ---
+
+func TestPreserveCreateState_KeepsFileIDs(t *testing.T) {
+	t.Parallel()
+
+	diskFileID := "vm-100-disk-0"
+	efiFileID := "vm-100-efidisk"
+	nodeName := "pve-node"
+
+	tests := []struct {
+		name       string
+		state      proxmox.VMInputs
+		userInputs proxmox.VMInputs
+		check      func(t *testing.T, result proxmox.VMInputs)
+	}{
+		{
+			name: "disk FileID kept when user omitted it",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+				Disks: []*proxmox.Disk{{
+					Interface: "scsi0",
+					DiskBase:  proxmox.DiskBase{Storage: "local-lvm", FileID: &diskFileID},
+					Size:      32,
+				}},
+			},
+			userInputs: proxmox.VMInputs{
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+				Disks: []*proxmox.Disk{{
+					Interface: "scsi0",
+					DiskBase:  proxmox.DiskBase{Storage: "local-lvm"},
+					Size:      32,
+				}},
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.Len(t, result.Disks, 1)
+				require.NotNil(t, result.Disks[0].FileID, "Create state must keep disk FileID")
+				assert.Equal(t, diskFileID, *result.Disks[0].FileID)
+			},
+		},
+		{
+			name: "EFI FileID kept when user omitted it",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+				EfiDisk: &proxmox.EfiDisk{
+					DiskBase: proxmox.DiskBase{Storage: "local-lvm", FileID: &efiFileID},
+					EfiType:  proxmox.EfiType4M,
+				},
+			},
+			userInputs: proxmox.VMInputs{
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+				EfiDisk: &proxmox.EfiDisk{
+					DiskBase: proxmox.DiskBase{Storage: "local-lvm"},
+					EfiType:  proxmox.EfiType4M,
+				},
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.NotNil(t, result.EfiDisk)
+				require.NotNil(t, result.EfiDisk.FileID, "Create state must keep EFI FileID")
+				assert.Equal(t, efiFileID, *result.EfiDisk.FileID)
+			},
+		},
+		{
+			name: "VMID and Node kept even if user hypothetically omitted them",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+			},
+			userInputs: proxmox.VMInputs{
+				// Simulating computed VMID/Node already set on request.Inputs
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.NotNil(t, result.VMID)
+				assert.Equal(t, 100, *result.VMID)
+				require.NotNil(t, result.Node)
+				assert.Equal(t, nodeName, *result.Node)
+			},
+		},
+		{
+			name: "clone info preserved from user inputs",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+			},
+			userInputs: proxmox.VMInputs{
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+				Clone: &proxmox.Clone{
+					VMID:      9000,
+					FullClone: testutils.Ptr(true),
+					Timeout:   300,
+				},
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.NotNil(t, result.Clone)
+				assert.Equal(t, 9000, result.Clone.VMID)
+				require.NotNil(t, result.Clone.FullClone)
+				assert.True(t, *result.Clone.FullClone)
+			},
+		},
+		{
+			name: "zero-value fields preserved in create state",
+			state: proxmox.VMInputs{
+				VMID:      testutils.Ptr(100),
+				Node:      &nodeName,
+				Balloon:   nil,
+				Autostart: nil,
+				Template:  nil,
+				CPU:       &proxmox.CPU{Cores: testutils.Ptr(2), Numa: nil},
+			},
+			userInputs: proxmox.VMInputs{
+				VMID:      testutils.Ptr(100),
+				Node:      &nodeName,
+				Balloon:   testutils.Ptr(0),
+				Autostart: testutils.Ptr(0),
+				Template:  testutils.Ptr(0),
+				CPU:       &proxmox.CPU{Cores: testutils.Ptr(2), Numa: testutils.Ptr(false)},
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.NotNil(t, result.Balloon)
+				assert.Equal(t, 0, *result.Balloon)
+				require.NotNil(t, result.Autostart)
+				assert.Equal(t, 0, *result.Autostart)
+				require.NotNil(t, result.Template)
+				assert.Equal(t, 0, *result.Template)
+				require.NotNil(t, result.CPU)
+				require.NotNil(t, result.CPU.Numa)
+				assert.False(t, *result.CPU.Numa)
+			},
+		},
+		{
+			name: "tags preserved in user order",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+				Tags: []string{"alpha", "beta", "gamma"},
+			},
+			userInputs: proxmox.VMInputs{
+				VMID: testutils.Ptr(100),
+				Node: &nodeName,
+				Tags: []string{"gamma", "beta", "alpha"},
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.Equal(t, []string{"gamma", "beta", "alpha"}, result.Tags)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := preserveCreateState(tt.state, tt.userInputs)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestPreserveInputs_ClearsFileIDs(t *testing.T) {
+	t.Parallel()
+
+	diskFileID := "vm-200-disk-0"
+	efiFileID := "vm-200-efidisk"
+	nodeName := "pve-node"
+
+	tests := []struct {
+		name       string
+		state      proxmox.VMInputs
+		userInputs proxmox.VMInputs
+		check      func(t *testing.T, result proxmox.VMInputs)
+	}{
+		{
+			name: "disk FileID cleared when user omitted it",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(200),
+				Node: &nodeName,
+				Disks: []*proxmox.Disk{{
+					Interface: "scsi0",
+					DiskBase:  proxmox.DiskBase{Storage: "local-lvm", FileID: &diskFileID},
+					Size:      32,
+				}},
+			},
+			userInputs: proxmox.VMInputs{
+				VMID: testutils.Ptr(200),
+				Node: &nodeName,
+				Disks: []*proxmox.Disk{{
+					Interface: "scsi0",
+					DiskBase:  proxmox.DiskBase{Storage: "local-lvm"},
+					Size:      32,
+				}},
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.Len(t, result.Disks, 1)
+				assert.Nil(t, result.Disks[0].FileID, "Read inputs must clear disk FileID when user omitted it")
+			},
+		},
+		{
+			name: "EFI FileID cleared when user omitted it",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(200),
+				Node: &nodeName,
+				EfiDisk: &proxmox.EfiDisk{
+					DiskBase: proxmox.DiskBase{Storage: "local-lvm", FileID: &efiFileID},
+					EfiType:  proxmox.EfiType4M,
+				},
+			},
+			userInputs: proxmox.VMInputs{
+				VMID: testutils.Ptr(200),
+				Node: &nodeName,
+				EfiDisk: &proxmox.EfiDisk{
+					DiskBase: proxmox.DiskBase{Storage: "local-lvm"},
+					EfiType:  proxmox.EfiType4M,
+				},
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.NotNil(t, result.EfiDisk)
+				assert.Nil(t, result.EfiDisk.FileID, "Read inputs must clear EFI FileID when user omitted it")
+			},
+		},
+		{
+			name: "VMID cleared when user omitted it",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(200),
+				Node: &nodeName,
+			},
+			userInputs: proxmox.VMInputs{
+				Node: &nodeName,
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				assert.Nil(t, result.VMID, "Read inputs must clear VMID when user omitted it")
+				require.NotNil(t, result.Node)
+			},
+		},
+		{
+			name: "Node cleared when user omitted it",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(200),
+				Node: &nodeName,
+			},
+			userInputs: proxmox.VMInputs{
+				VMID: testutils.Ptr(200),
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.NotNil(t, result.VMID)
+				assert.Nil(t, result.Node, "Read inputs must clear Node when user omitted it")
+			},
+		},
+		{
+			name: "disk FileID kept when user explicitly provided it",
+			state: proxmox.VMInputs{
+				VMID: testutils.Ptr(200),
+				Node: &nodeName,
+				Disks: []*proxmox.Disk{{
+					Interface: "scsi0",
+					DiskBase:  proxmox.DiskBase{Storage: "local-lvm", FileID: &diskFileID},
+					Size:      32,
+				}},
+			},
+			userInputs: proxmox.VMInputs{
+				VMID: testutils.Ptr(200),
+				Node: &nodeName,
+				Disks: []*proxmox.Disk{{
+					Interface: "scsi0",
+					DiskBase:  proxmox.DiskBase{Storage: "local-lvm", FileID: &diskFileID},
+					Size:      32,
+				}},
+			},
+			check: func(t *testing.T, result proxmox.VMInputs) {
+				require.Len(t, result.Disks, 1)
+				require.NotNil(t, result.Disks[0].FileID, "Read inputs must keep FileID when user provided it")
+				assert.Equal(t, diskFileID, *result.Disks[0].FileID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := preserveInputs(tt.state, tt.userInputs)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestCreateFullLifecycle_FileIDsInState(t *testing.T) {
+	t.Parallel()
+
+	nodeName := "pve-node"
+	vmID := 700
+	diskFileID := "vm-700-disk-0"
+	efiFileID := "vm-700-efidisk"
+
+	ops := &mockVMOps{
+		createVMFunc: func(_ context.Context, _ proxmox.VMInputs) error {
+			return nil
+		},
+		getFunc: func(_ context.Context, id int, _ *string, _ []*proxmox.Disk) (proxmox.VMInputs, error) {
+			return proxmox.VMInputs{
+				VMID: &id,
+				Node: testutils.Ptr(nodeName),
+				Name: "lifecycle-vm",
+				Disks: []*proxmox.Disk{
+					{
+						Interface: "scsi0",
+						DiskBase:  proxmox.DiskBase{Storage: "local-lvm", FileID: &diskFileID},
+						Size:      32,
+					},
+				},
+				EfiDisk: &proxmox.EfiDisk{
+					DiskBase: proxmox.DiskBase{Storage: "local-lvm", FileID: &efiFileID},
+					EfiType:  proxmox.EfiType4M,
+				},
+			}, nil
+		},
+	}
+
+	vmRes := &VM{VMOps: ops, Client: &testutils.MockProxmoxClient{DefaultNode: nodeName, DefaultVMID: vmID}}
+
+	// Step 1: Create — FileIDs should be in the state
+	createReq := infer.CreateRequest[proxmox.VMInputs]{
+		Name: "lifecycle-vm",
+		Inputs: proxmox.VMInputs{
+			Name: "lifecycle-vm",
+			Node: &nodeName,
+			Disks: []*proxmox.Disk{{
+				Interface: "scsi0",
+				DiskBase:  proxmox.DiskBase{Storage: "local-lvm"},
+				Size:      32,
+			}},
+			EfiDisk: &proxmox.EfiDisk{
+				DiskBase: proxmox.DiskBase{Storage: "local-lvm"},
+				EfiType:  proxmox.EfiType4M,
+			},
+		},
+	}
+
+	createResp, err := vmRes.Create(context.Background(), createReq)
+	require.NoError(t, err)
+
+	// Verify FileIDs are stored in state after Create
+	require.Len(t, createResp.Output.Disks, 1)
+	require.NotNil(t, createResp.Output.Disks[0].FileID, "disk FileID must be in state after Create")
+	assert.Equal(t, diskFileID, *createResp.Output.Disks[0].FileID)
+	require.NotNil(t, createResp.Output.EfiDisk)
+	require.NotNil(t, createResp.Output.EfiDisk.FileID, "EFI FileID must be in state after Create")
+	assert.Equal(t, efiFileID, *createResp.Output.EfiDisk.FileID)
+
+	// Step 2: Use that state in an Update (dry-run) — FileIDs should propagate
+	updateReq := infer.UpdateRequest[proxmox.VMInputs, proxmox.VMOutputs]{
+		ID:     "lifecycle-vm",
+		DryRun: true,
+		Inputs: proxmox.VMInputs{
+			Name: "lifecycle-vm",
+			Node: &nodeName,
+			Disks: []*proxmox.Disk{{
+				Interface: "scsi0",
+				DiskBase:  proxmox.DiskBase{Storage: "local-lvm"},
+				Size:      32,
+			}},
+			EfiDisk: &proxmox.EfiDisk{
+				DiskBase: proxmox.DiskBase{Storage: "local-lvm"},
+				EfiType:  proxmox.EfiType4M,
+			},
+		},
+		State: createResp.Output,
+	}
+
+	updateResp, err := vmRes.Update(context.Background(), updateReq)
+	require.NoError(t, err)
+
+	// FileIDs should be copied from state into update output
+	require.Len(t, updateResp.Output.Disks, 1)
+	require.NotNil(t, updateResp.Output.Disks[0].FileID, "disk FileID must propagate from state to Update output")
+	assert.Equal(t, diskFileID, *updateResp.Output.Disks[0].FileID)
+	require.NotNil(t, updateResp.Output.EfiDisk)
+	require.NotNil(t, updateResp.Output.EfiDisk.FileID, "EFI FileID must propagate from state to Update output")
+	assert.Equal(t, efiFileID, *updateResp.Output.EfiDisk.FileID)
 }

--- a/provider/pkg/provider/resources/vm/vm_computed_fields_test.go
+++ b/provider/pkg/provider/resources/vm/vm_computed_fields_test.go
@@ -579,29 +579,14 @@ func TestVMCreateOutputsContainComputedValues(t *testing.T) {
 
 	nodeName := "pve-node"
 	nextID := 500
-	diskFileID := "vm-500-disk-0"
-	efiFileID := "vm-500-efidisk"
 
 	ops := &mockVMOps{
-		createVMFunc: func(_ context.Context, inputs proxmox.VMInputs) error {
+		createVMFunc: func(_ context.Context, _ proxmox.VMInputs) error {
 			return nil
 		},
-		getFunc: func(
-			_ context.Context, id int, node *string, _ []*proxmox.Disk,
-		) (proxmox.VMInputs, error) {
-			return proxmox.VMInputs{
-				VMID: &id,
-				Node: testutils.Ptr(nodeName),
-				Disks: []*proxmox.Disk{{
-					Interface: "scsi0",
-					DiskBase:  proxmox.DiskBase{Storage: "local-lvm", FileID: &diskFileID},
-					Size:      32,
-				}},
-				EfiDisk: &proxmox.EfiDisk{
-					DiskBase: proxmox.DiskBase{Storage: "local-lvm", FileID: &efiFileID},
-					EfiType:  proxmox.EfiType4M,
-				},
-			}, nil
+		getFunc: func(_ context.Context, _ int, _ *string, _ []*proxmox.Disk) (proxmox.VMInputs, error) {
+			t.Fatal("Create must not read VM state from API")
+			return proxmox.VMInputs{}, nil
 		},
 	}
 
@@ -624,11 +609,11 @@ func TestVMCreateOutputsContainComputedValues(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "500", resp.ID)
 
-	// proxmox.VMOutputs contain computed VMID
+	// Outputs contain computed VMID resolved during create
 	require.NotNil(t, resp.Output.VMID)
 	assert.Equal(t, nextID, *resp.Output.VMID)
 
-	// proxmox.VMInputs should not contain computed VMID (user omitted it)
+	// Original request inputs should not have been mutated with computed VMID
 	assert.Nil(t, req.Inputs.VMID)
 }
 
@@ -786,4 +771,197 @@ func TestVMReadPreservesCloneFromInputs(t *testing.T) {
 			require.Equal(t, tt.wantClone, resp.State.Clone, "clone should be preserved in State")
 		})
 	}
+}
+
+func TestPreserveInputs_ZeroValueFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		state      proxmox.VMInputs
+		userInputs proxmox.VMInputs
+		check      func(t *testing.T, preserved proxmox.VMInputs)
+	}{
+		{
+			name: "balloon 0 preserved when API returns nil",
+			state: proxmox.VMInputs{
+				Balloon: nil, // API returned 0 → adapter returns nil
+			},
+			userInputs: proxmox.VMInputs{
+				Balloon: testutils.Ptr(0), // user explicitly disabled
+			},
+			check: func(t *testing.T, preserved proxmox.VMInputs) {
+				require.NotNil(t, preserved.Balloon)
+				assert.Equal(t, 0, *preserved.Balloon)
+			},
+		},
+		{
+			name: "balloon non-zero not overwritten",
+			state: proxmox.VMInputs{
+				Balloon: testutils.Ptr(256), // API returned 256
+			},
+			userInputs: proxmox.VMInputs{
+				Balloon: testutils.Ptr(512), // user wanted 512 (drift scenario)
+			},
+			check: func(t *testing.T, preserved proxmox.VMInputs) {
+				require.NotNil(t, preserved.Balloon)
+				assert.Equal(t, 256, *preserved.Balloon, "should keep API value for drift detection")
+			},
+		},
+		{
+			name: "autostart 0 preserved when API returns nil",
+			state: proxmox.VMInputs{
+				Autostart: nil,
+			},
+			userInputs: proxmox.VMInputs{
+				Autostart: testutils.Ptr(0),
+			},
+			check: func(t *testing.T, preserved proxmox.VMInputs) {
+				require.NotNil(t, preserved.Autostart)
+				assert.Equal(t, 0, *preserved.Autostart)
+			},
+		},
+		{
+			name: "autostart non-zero not overwritten",
+			state: proxmox.VMInputs{
+				Autostart: testutils.Ptr(1),
+			},
+			userInputs: proxmox.VMInputs{
+				Autostart: testutils.Ptr(0), // user wants disabled but API shows enabled
+			},
+			check: func(t *testing.T, preserved proxmox.VMInputs) {
+				require.NotNil(t, preserved.Autostart)
+				assert.Equal(t, 1, *preserved.Autostart, "should keep API value for drift detection")
+			},
+		},
+		{
+			name: "template 0 preserved when API returns nil",
+			state: proxmox.VMInputs{
+				Template: nil,
+			},
+			userInputs: proxmox.VMInputs{
+				Template: testutils.Ptr(0),
+			},
+			check: func(t *testing.T, preserved proxmox.VMInputs) {
+				require.NotNil(t, preserved.Template)
+				assert.Equal(t, 0, *preserved.Template)
+			},
+		},
+		{
+			name: "numa false preserved when API returns nil",
+			state: proxmox.VMInputs{
+				CPU: &proxmox.CPU{Cores: testutils.Ptr(2), Numa: nil},
+			},
+			userInputs: proxmox.VMInputs{
+				CPU: &proxmox.CPU{Cores: testutils.Ptr(2), Numa: testutils.Ptr(false)},
+			},
+			check: func(t *testing.T, preserved proxmox.VMInputs) {
+				require.NotNil(t, preserved.CPU)
+				require.NotNil(t, preserved.CPU.Numa)
+				assert.False(t, *preserved.CPU.Numa)
+			},
+		},
+		{
+			name: "numa not overwritten when API returns true",
+			state: proxmox.VMInputs{
+				CPU: &proxmox.CPU{Cores: testutils.Ptr(2), Numa: testutils.Ptr(true)},
+			},
+			userInputs: proxmox.VMInputs{
+				CPU: &proxmox.CPU{Cores: testutils.Ptr(2), Numa: testutils.Ptr(false)},
+			},
+			check: func(t *testing.T, preserved proxmox.VMInputs) {
+				require.NotNil(t, preserved.CPU)
+				require.NotNil(t, preserved.CPU.Numa)
+				assert.True(t, *preserved.CPU.Numa, "should keep API value for drift detection")
+			},
+		},
+		{
+			name: "user nil fields stay nil",
+			state: proxmox.VMInputs{
+				Balloon:   nil,
+				Autostart: nil,
+				Template:  nil,
+			},
+			userInputs: proxmox.VMInputs{
+				Balloon:   nil, // user never set these
+				Autostart: nil,
+				Template:  nil,
+			},
+			check: func(t *testing.T, preserved proxmox.VMInputs) {
+				assert.Nil(t, preserved.Balloon)
+				assert.Nil(t, preserved.Autostart)
+				assert.Nil(t, preserved.Template)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			preserved := preserveInputs(tt.state, tt.userInputs)
+			tt.check(t, preserved)
+		})
+	}
+}
+
+func TestVMReadStatePreservesZeroValueFields(t *testing.T) {
+	t.Parallel()
+
+	vmID := 500
+	nodeName := "pve-node"
+
+	ops := &mockVMOps{
+		getFunc: func(_ context.Context, id int, _ *string, _ []*proxmox.Disk) (proxmox.VMInputs, error) {
+			// Simulate API: returns nil for all zero-value fields
+			return proxmox.VMInputs{
+				VMID:      &id,
+				Node:      testutils.Ptr(nodeName),
+				Name:      "zero-val-vm",
+				Balloon:   nil, // API returned 0 → adapter intOrNil(0) = nil
+				Autostart: nil, // same
+				Template:  nil, // same
+				CPU:       &proxmox.CPU{Cores: testutils.Ptr(2), Numa: nil},
+			}, nil
+		},
+	}
+
+	vmRes := &VM{VMOps: ops, Client: &testutils.MockProxmoxClient{DefaultNode: nodeName, DefaultVMID: vmID}}
+	req := infer.ReadRequest[proxmox.VMInputs, proxmox.VMOutputs]{
+		ID: "500",
+		Inputs: proxmox.VMInputs{
+			VMID:      testutils.Ptr(vmID),
+			Node:      &nodeName,
+			Balloon:   testutils.Ptr(0), // user explicitly disabled balloon
+			Autostart: testutils.Ptr(0), // user explicitly disabled autostart
+			Template:  testutils.Ptr(0), // user explicitly set not-template
+			CPU:       &proxmox.CPU{Cores: testutils.Ptr(2), Numa: testutils.Ptr(false)},
+		},
+		State: proxmox.VMOutputs{VMInputs: proxmox.VMInputs{VMID: testutils.Ptr(vmID)}},
+	}
+
+	resp, err := vmRes.Read(context.Background(), req)
+	require.NoError(t, err)
+
+	// Inputs should have zero-value fields preserved
+	require.NotNil(t, resp.Inputs.Balloon)
+	assert.Equal(t, 0, *resp.Inputs.Balloon)
+	require.NotNil(t, resp.Inputs.Autostart)
+	assert.Equal(t, 0, *resp.Inputs.Autostart)
+	require.NotNil(t, resp.Inputs.Template)
+	assert.Equal(t, 0, *resp.Inputs.Template)
+	require.NotNil(t, resp.Inputs.CPU)
+	require.NotNil(t, resp.Inputs.CPU.Numa)
+	assert.False(t, *resp.Inputs.CPU.Numa)
+
+	// State (written to state file) must ALSO preserve these fields
+	// to prevent spurious diffs on next `pulumi up`
+	require.NotNil(t, resp.State.Balloon, "state file must record balloon=0")
+	assert.Equal(t, 0, *resp.State.Balloon)
+	require.NotNil(t, resp.State.Autostart, "state file must record autostart=0")
+	assert.Equal(t, 0, *resp.State.Autostart)
+	require.NotNil(t, resp.State.Template, "state file must record template=0")
+	assert.Equal(t, 0, *resp.State.Template)
+	require.NotNil(t, resp.State.CPU)
+	require.NotNil(t, resp.State.CPU.Numa, "state file must record numa=false")
+	assert.False(t, *resp.State.CPU.Numa)
 }

--- a/provider/pkg/provider/resources/vm/vm_create_errors_test.go
+++ b/provider/pkg/provider/resources/vm/vm_create_errors_test.go
@@ -1,0 +1,120 @@
+/* Copyright 2025, Pulumi Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/hctamu/pulumi-pve/provider/pkg/provider/resources/vm"
+	"github.com/hctamu/pulumi-pve/provider/pkg/proxmox"
+	"github.com/hctamu/pulumi-pve/provider/pkg/testutils"
+)
+
+// mockErrorClient is a proxmox.Client that returns configurable errors for
+// ResolveNode and NextVMID, allowing error-path testing of the VM resource.
+type mockErrorClient struct {
+	resolveNodeErr error
+	nextVMIDErr    error
+}
+
+func (mock *mockErrorClient) Get(_ context.Context, _ string, _ any) error     { return nil }
+func (mock *mockErrorClient) Post(_ context.Context, _ string, _, _ any) error { return nil }
+func (mock *mockErrorClient) Put(_ context.Context, _ string, _, _ any) error  { return nil }
+func (mock *mockErrorClient) Delete(_ context.Context, _ string, _ any) error  { return nil }
+
+func (mock *mockErrorClient) ResolveNode(_ context.Context, _ *string) (string, error) {
+	return "", mock.resolveNodeErr
+}
+
+func (mock *mockErrorClient) NextVMID(_ context.Context) (int, error) {
+	return 0, mock.nextVMIDErr
+}
+
+func TestVMCreateConfigurationErrors(t *testing.T) {
+	t.Parallel()
+
+	nodeName := "pve-node"
+	resolveErr := errors.New("cluster unreachable")
+	nextIDErr := errors.New("no VMID available")
+
+	tests := []struct {
+		name           string
+		client         proxmox.Client
+		vmOps          proxmox.VMOperations
+		inputs         proxmox.VMInputs
+		wantErrContain string
+		wantErr        error // non-nil to check exact error identity
+	}{
+		{
+			name:           "VMOperations not configured",
+			client:         &testutils.MockProxmoxClient{DefaultNode: "pve-node", DefaultVMID: 100},
+			vmOps:          nil,
+			inputs:         proxmox.VMInputs{},
+			wantErrContain: "VMOperations not configured",
+		},
+		{
+			name:           "Client not configured",
+			client:         nil,
+			vmOps:          &mockVMOperations{},
+			inputs:         proxmox.VMInputs{},
+			wantErrContain: "client not configured",
+		},
+		{
+			name:    "ResolveNode failure is propagated",
+			client:  &mockErrorClient{resolveNodeErr: resolveErr},
+			vmOps:   &mockVMOperations{},
+			inputs:  proxmox.VMInputs{},
+			wantErr: resolveErr,
+		},
+		{
+			name:   "NextVMID failure is propagated",
+			client: &mockErrorClient{nextVMIDErr: nextIDErr},
+			vmOps:  &mockVMOperations{},
+			inputs: proxmox.VMInputs{
+				Name: "test-vm",
+				Node: &nodeName,
+				// VMID is nil so NextVMID is called
+			},
+			wantErr: nextIDErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			vmRes := &vm.VM{Client: tt.client, VMOps: tt.vmOps}
+			req := infer.CreateRequest[proxmox.VMInputs]{Name: "test", Inputs: tt.inputs}
+
+			_, err := vmRes.Create(context.Background(), req)
+			require.Error(t, err)
+
+			if tt.wantErr != nil {
+				assert.Equal(t, tt.wantErr, err)
+			}
+			if tt.wantErrContain != "" {
+				assert.Contains(t, err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}

--- a/provider/pkg/provider/resources/vm/vm_numa_false_test.go
+++ b/provider/pkg/provider/resources/vm/vm_numa_false_test.go
@@ -87,7 +87,7 @@ func TestVMReadPreservesNumaFalse(t *testing.T) {
 }
 
 // TestVMCreatePreservesNumaFalse verifies that Create stores numa: false in the output
-// state without calling Get (the old readCurrentOutput behavior which masked user input).
+// state by reading back the VM and applying preserveInputs.
 func TestVMCreatePreservesNumaFalse(t *testing.T) {
 	t.Parallel()
 
@@ -98,9 +98,19 @@ func TestVMCreatePreservesNumaFalse(t *testing.T) {
 		createVMFunc: func(_ context.Context, _ proxmox.VMInputs) error {
 			return nil
 		},
-		getFunc: func(_ context.Context, _ int, _ *string, _ []*proxmox.Disk) (proxmox.VMInputs, error) {
-			t.Fatal("Create must not read VM state from API — that masked user inputs")
-			return proxmox.VMInputs{}, nil
+		getFunc: func(_ context.Context, id int, _ *string, _ []*proxmox.Disk) (proxmox.VMInputs, error) {
+			// Simulate what Proxmox returns: numa=0 means the field is nil in our domain model
+			return proxmox.VMInputs{
+				VMID: &id,
+				Name: "numa-false-test",
+				Node: testutils.Ptr(nodeName),
+				CPU: &proxmox.CPU{
+					Cores:   testutils.Ptr(2),
+					Sockets: testutils.Ptr(1),
+					Numa:    nil, // API returns nil when numa is 0 (disabled)
+				},
+				Disks: []*proxmox.Disk{},
+			}, nil
 		},
 	}
 

--- a/provider/pkg/provider/resources/vm/vm_numa_false_test.go
+++ b/provider/pkg/provider/resources/vm/vm_numa_false_test.go
@@ -1,0 +1,134 @@
+/* Copyright 2025, Pulumi Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/hctamu/pulumi-pve/provider/pkg/provider/resources/vm"
+	"github.com/hctamu/pulumi-pve/provider/pkg/proxmox"
+	"github.com/hctamu/pulumi-pve/provider/pkg/testutils"
+)
+
+// TestVMReadPreservesNumaFalse verifies that when a user explicitly sets numa: false,
+// it is preserved in the state after a read operation. This test addresses the issue where
+// numa: false was not preserved, causing spurious diffs on every update.
+func TestVMReadPreservesNumaFalse(t *testing.T) {
+	t.Parallel()
+
+	vmID := 100
+	nodeName := "pve-node"
+
+	mockOps := &mockVMOperations{
+		getFunc: func(_ context.Context, _ int, _ *string, _ []*proxmox.Disk) (proxmox.VMInputs, error) {
+			// Simulate what Proxmox returns: numa=0 means the field is nil in our domain model
+			return proxmox.VMInputs{
+				VMID: testutils.Ptr(vmID),
+				Name: "numa-false-test",
+				CPU: &proxmox.CPU{
+					Cores:   testutils.Ptr(2),
+					Sockets: testutils.Ptr(1),
+					Numa:    nil, // API returns nil when numa is 0 (disabled)
+				},
+			}, nil
+		},
+	}
+
+	vmRes := &vm.VM{
+		Client: &testutils.MockProxmoxClient{DefaultNode: nodeName, DefaultVMID: vmID},
+		VMOps:  mockOps,
+	}
+
+	numaFalse := false
+	req := infer.ReadRequest[proxmox.VMInputs, proxmox.VMOutputs]{
+		ID: "100",
+		Inputs: proxmox.VMInputs{
+			VMID: testutils.Ptr(vmID),
+			Node: &nodeName,
+			CPU: &proxmox.CPU{
+				Cores:   testutils.Ptr(2),
+				Sockets: testutils.Ptr(1),
+				Numa:    &numaFalse, // User specified numa: false
+			},
+		},
+	}
+
+	resp, err := vmRes.Read(context.Background(), req)
+	require.NoError(t, err)
+
+	// preserveInputs must keep the user's explicit numa: false in Inputs
+	require.NotNil(t, resp.Inputs.CPU)
+	require.NotNil(t, resp.Inputs.CPU.Numa, "numa: false must not be dropped to nil by preserveInputs")
+	assert.False(t, *resp.Inputs.CPU.Numa)
+
+	// State must also preserve user's numa: false so the state file records user intent
+	require.NotNil(t, resp.State.CPU)
+	require.NotNil(t, resp.State.CPU.Numa, "state must preserve numa: false for state file")
+	assert.False(t, *resp.State.CPU.Numa)
+}
+
+// TestVMCreatePreservesNumaFalse verifies that Create stores numa: false in the output
+// state without calling Get (the old readCurrentOutput behavior which masked user input).
+func TestVMCreatePreservesNumaFalse(t *testing.T) {
+	t.Parallel()
+
+	vmID := 100
+	nodeName := "pve-node"
+
+	mockOps := &mockVMOperations{
+		createVMFunc: func(_ context.Context, _ proxmox.VMInputs) error {
+			return nil
+		},
+		getFunc: func(_ context.Context, _ int, _ *string, _ []*proxmox.Disk) (proxmox.VMInputs, error) {
+			t.Fatal("Create must not read VM state from API — that masked user inputs")
+			return proxmox.VMInputs{}, nil
+		},
+	}
+
+	vmRes := &vm.VM{
+		Client: &testutils.MockProxmoxClient{DefaultNode: nodeName, DefaultVMID: vmID},
+		VMOps:  mockOps,
+	}
+
+	numaFalse := false
+	createReq := infer.CreateRequest[proxmox.VMInputs]{
+		Name: "numa-false-test",
+		Inputs: proxmox.VMInputs{
+			Name: "numa-false-test",
+			Node: &nodeName,
+			CPU: &proxmox.CPU{
+				Cores:   testutils.Ptr(2),
+				Sockets: testutils.Ptr(1),
+				Numa:    &numaFalse,
+			},
+			Disks: []*proxmox.Disk{},
+		},
+	}
+
+	createResp, err := vmRes.Create(context.Background(), createReq)
+	require.NoError(t, err)
+
+	// Output state must contain the user's numa: false, not nil
+	require.NotNil(t, createResp.Output.CPU)
+	require.NotNil(t, createResp.Output.CPU.Numa, "Create output must preserve numa: false")
+	assert.False(t, *createResp.Output.CPU.Numa)
+}


### PR DESCRIPTION
preserve zero-value fields (balloon, autostart, template, numa) in state

Fields set to zero/false were lost during Read because the adapter cannot distinguish "explicitly zero" from "unset". Preserve user intent in both Inputs and State output so the state file prevents spurious diffs.